### PR TITLE
Add RB2DX Disc Builder to the tools list

### DIFF
--- a/docs/downloads.html
+++ b/docs/downloads.html
@@ -95,6 +95,14 @@
 
 <h3>📥 <a href="https://bit.ly/nemoNAUTILUS">Download</a></h3>
 
+<br>
+
+<h2>RB2DX Disc Builder</h2>
+
+<p><em>RB2DX Disc Builder makes a PlayStation 2 disc image of Deluxe Custom Edition with your own songs on it, converting Clone Hero charts, audio and album art so they play on console. <a href="https://github.com/PhayMo/rb2dx-disc-builder">Source Code</a></em></p>
+
+<h3>📥 <a href="https://github.com/PhayMo/rb2dx-disc-builder/releases">Download</a></h3>
+
 </main>
 <footer>
 	<a href="https://milohax.org/"><img src="images/milohax.png" alt="MiloHax"></a>

--- a/docs/downloads_es.html
+++ b/docs/downloads_es.html
@@ -95,6 +95,14 @@
 
 <h3>📥 <a href="https://bit.ly/nemoNAUTILUS">Descargar</a></h3>
 
+<br>
+
+<h2>RB2DX Disc Builder</h2>
+
+<p><em>RB2DX Disc Builder crea una imagen de disco de PlayStation 2 de Deluxe Custom Edition con tus propias canciones, convirtiendo las notas, el audio y la portada de canciones de Clone Hero para que funcionen en la consola. <a href="https://github.com/PhayMo/rb2dx-disc-builder">Código Fuente</a></em></p>
+
+<h3>📥 <a href="https://github.com/PhayMo/rb2dx-disc-builder/releases">Descargar</a></h3>
+
 </main>
 <footer>
 	<a href="https://milohax.org/"><img src="images/milohax.png" alt="MiloHax"></a>


### PR DESCRIPTION
Adds RB2DX Disc Builder to the optional tools on the downloads page, in both English and Spanish.

It builds a PS2 disc image of Deluxe Custom Edition with custom songs on it. Point it at folders of Clone Hero songs and it converts the charts, mixes the stems into the channel layout the PS2 build expects, converts album art, encodes the audio and background video, injects everything into the game's archive and writes a bootable ISO. It has a GUI and a command line, downloads the tools it needs on first run, and is free and open source under the MIT license.

- Source: https://github.com/PhayMo/rb2dx-disc-builder
- Releases: https://github.com/PhayMo/rb2dx-disc-builder/releases

Happy to reword the blurb, shorten it or move the entry if you would rather it sat somewhere else on the page.