### PR TITLE
Add a PS2 (Custom Edition) tab to the install guide

### DIFF
--- a/docs/install.html
+++ b/docs/install.html
@@ -106,6 +106,7 @@ body {font-family: Arial;}
   <button class="tablinks" onclick="openCity(event, 'RPCS3')">RPCS3</button>
   <button class="tablinks" onclick="openCity(event, 'PS3')">PS3</button>
   <button class="tablinks" onclick="openCity(event, 'Xbox 360')">Xbox 360</button>
+  <button class="tablinks" onclick="openCity(event, 'PS2')">PS2 (Custom Edition)</button>
 </div>
 
 <div id="RPCS3" class="tabcontent">
@@ -200,6 +201,47 @@ body {font-family: Arial;}
 </ul>
 
 <h3>✅ <em>Rock Band 2 Deluxe is now installed and ready to play!</em></h3>
+</div>
+
+<div id="PS2" class="tabcontent">
+<h2>Installing on PS2 (Custom Edition)*</h2>
+
+<blockquote>
+    <p>*RB2DX requires a PS2 that runs backups (Free McBoot, FreeDVDBoot or a modchip) in order to run.</p>
+</blockquote>
+
+<h3>Download <a href="downloads.html">Rock Band 2 Deluxe (Custom Edition)</a> if you haven't already</h3>
+
+<p>Before you start, Custom Edition has no charts. You'll need to convert your own songs and build the PS2 disc using <a href="https://github.com/PhayMo/rb2dx-disc-builder/releases">RB2DX Disc Builder</a>.</p>
+
+<h3>Build the disc</h3>
+
+<ul>
+    <li>Extract the builder and run <code>RB2DX Disc Builder.exe</code>. <em>The first start takes a good twenty seconds while it unpacks itself, with nothing on screen until the window appears.</em></li>
+    <li>On the <strong>Setup</strong> page, fill in the folders it asks for, starting with the Custom Edition folder you extracted.</li>
+    <li>Press <strong>Download what's missing</strong> to fetch the tools, then select <code>ps2str.exe</code> in the list and use <strong>Locate the selected tool...</strong> to point at your own copy.</li>
+    <li>Add the folders your songs live in, then on the <strong>Songs</strong> page <strong>scan</strong> and tick what you want.</li>
+    <li>Once you are ready, go to the <strong>Build</strong> page and press <strong>Build the disc</strong>.</li>
+</ul>
+
+<h3>Playing it on a console</h3>
+
+<p>Copy the ISO to the console's hard drive or an MX4SIO SD card and launch it from Open PS2 Loader.</p>
+
+<h3>Playing it in PCSX2</h3>
+
+<p>PCSX2 will not boot the ISO the builder writes, though a real PS2 will, so have it save the disc's files and make the image with <a href="https://www.imgburn.com/">ImgBurn</a> instead:</p>
+
+<ul>
+    <li>Tick <strong>Also save the disc's files in a folder</strong>.</li>
+    <li>Set the file system to <strong>ISO9660 + UDF</strong> with <strong>UDF revision 1.02</strong>, then write the image and load it in PCSX2.</li>
+</ul>
+
+<h3>✅ <em>Rock Band 2 Deluxe is now installed and ready to play!</em></h3>
+
+<blockquote>
+    <p>Rock on!</p>
+</blockquote>
 </div>
 
 </div>

--- a/docs/install_es.html
+++ b/docs/install_es.html
@@ -106,6 +106,7 @@ body {font-family: Arial;}
   <button class="tablinks" onclick="openPlat(event, 'RPCS3')">RPCS3</button>
   <button class="tablinks" onclick="openPlat(event, 'PS3')">PS3</button>
   <button class="tablinks" onclick="openPlat(event, 'Xbox 360')">Xbox 360</button>
+  <button class="tablinks" onclick="openPlat(event, 'PS2')">PS2 (Custom Edition)</button>
 </div>
 
 <div id="RPCS3" class="tabcontent">
@@ -198,6 +199,47 @@ body {font-family: Arial;}
 </ul>
 
 <h3>✅ <em>¡Rock Band 2 Deluxe está instalado y listo para jugar!</em></h3>
+</div>
+
+<div id="PS2" class="tabcontent">
+<h2>Instalando en PS2 (Custom Edition)*</h2>
+
+<blockquote>
+   <p>*RB2DX requiere una PS2 capaz de ejecutar copias de seguridad (Free McBoot, FreeDVDBoot o un modchip) para funcionar.</p>
+</blockquote>
+
+<h3>Descarga <a href="downloads_es.html">Rock Band 2 Deluxe (Custom Edition)</a> si todavía no lo has hecho</h3>
+
+<p>Antes de empezar, Custom Edition no incluye canciones. Tendrás que convertir tus propias canciones y crear el disco de PS2 con <a href="https://github.com/PhayMo/rb2dx-disc-builder/releases">RB2DX Disc Builder</a>.</p>
+
+<h3>Crea el disco</h3>
+
+<ul>
+    <li>Extrae el programa y ejecuta <code>RB2DX Disc Builder.exe</code>. <em>El primer arranque tarda unos veinte segundos mientras se descomprime, sin nada en pantalla hasta que aparece la ventana.</em></li>
+    <li>En la página <strong>Setup</strong>, indica las carpetas que te pide, empezando por la carpeta de Custom Edition que extrajiste.</li>
+    <li>Pulsa <strong>Download what's missing</strong> para descargar las herramientas, luego selecciona <code>ps2str.exe</code> en la lista y usa <strong>Locate the selected tool...</strong> para indicar tu propia copia.</li>
+    <li>Añade las carpetas donde están tus canciones y luego, en la página <strong>Songs</strong>, pulsa <strong>scan</strong> y marca las que quieras.</li>
+    <li>Cuando estés listo, ve a la página <strong>Build</strong> y pulsa <strong>Build the disc</strong>.</li>
+</ul>
+
+<h3>Jugarlo en una consola</h3>
+
+<p>Copia la ISO al disco duro de la consola o a una tarjeta SD por MX4SIO y ejecútala desde Open PS2 Loader.</p>
+
+<h3>Jugarlo en PCSX2</h3>
+
+<p>PCSX2 no arranca la ISO que crea el programa, aunque una PS2 real sí lo hace, así que deja que guarde los archivos del disco y crea la imagen con <a href="https://www.imgburn.com/">ImgBurn</a> en su lugar:</p>
+
+<ul>
+    <li>Marca <strong>Also save the disc's files in a folder</strong>.</li>
+    <li>Configura el sistema de archivos como <strong>ISO9660 + UDF</strong> con <strong>UDF revisión 1.02</strong>, luego crea la imagen y cárgala en PCSX2.</li>
+</ul>
+
+<h3>✅ <em>¡Rock Band 2 Deluxe está instalado y listo para jugar!</em></h3>
+
+<blockquote>
+    <p>¡A rockear!</p>
+</blockquote>
 </div>
 
 </div>


### PR DESCRIPTION
Adds a **PS2 (Custom Edition)** tab to the installation guide, on both the English and Spanish pages.

Checked in a browser on both pages: the new button opens only its own tab and takes the active style, and the existing tabs still behave the same.
